### PR TITLE
fixed crash in updating rate configs

### DIFF
--- a/store/cluster.go
+++ b/store/cluster.go
@@ -212,8 +212,10 @@ func (s *Store) SyncKeys(ctx thrift.Context, syncs []*com.SyncCommand) error {
 func (cs *Store) SyncRateConfig(ctx thrift.Context, key string, threshold int32, window int32, peakaveraged bool) error {
 
 	log.Infof("Cluster:Done Sync rateconfig Request Key:%s, Threshold: %d , Window: %d, peakaveraged: %t", key, threshold, window, peakaveraged)
+	cs.Lock()
 	cs.rateConfig[key] = &RateConfig{Limit: threshold, Window: window,
 		PeakAveraged: peakaveraged}
+	cs.Unlock()
 	cs.SaveRateConfig()
 	return nil
 }

--- a/store/store.go
+++ b/store/store.go
@@ -471,9 +471,9 @@ func (s *Store) StatsDClient() *statsd.Client {
 
 func (s *Store) SaveRateConfig() {
 	s.RLock()
+	defer s.RUnlock()
 	json, _ := json.Marshal(s.rateConfig)
 	ioutil.WriteFile(s.opts.configDir+"rateconfig.json", json, 0644)
-	s.RUnlock()
 }
 
 func (s *Store) LoadRateConfig() {

--- a/store/store.go
+++ b/store/store.go
@@ -373,7 +373,9 @@ func (s *Store) startSyncWorker() {
 	}()
 }
 func (s *Store) SetRateConfig(key string, rateConfig RateConfig) {
+	s.Lock()
 	s.rateConfig[key] = &rateConfig
+	s.Unlock()
 	s.SaveRateConfig()
 	s.sendSyncRateConfigToNodes(key, &rateConfig)
 }
@@ -468,8 +470,10 @@ func (s *Store) StatsDClient() *statsd.Client {
 }
 
 func (s *Store) SaveRateConfig() {
+	s.RLock()
 	json, _ := json.Marshal(s.rateConfig)
 	ioutil.WriteFile(s.opts.configDir+"rateconfig.json", json, 0644)
+	s.RUnlock()
 }
 
 func (s *Store) LoadRateConfig() {


### PR DESCRIPTION
Fix for crash due to concurrent read and write:

Crash Log stacktrace:


> 
> fatal error: concurrent map iteration and map write
> 
> goroutine 10652 [running]:
> runtime.throw(0xe4b20f, 0x26)
> 	/var/lib/jenkins/tools/org.jenkinsci.plugins.golang.GolangInstallation/go1.10.1/src/runtime/panic.go:616 +0x81 fp=0xc42ab47640 sp=0xc42ab47620 pc=0x42c941
> runtime.mapiternext(0xc42d66b740)
> 	/var/lib/jenkins/tools/org.jenkinsci.plugins.golang.GolangInstallation/go1.10.1/src/runtime/hashmap.go:747 +0x55c fp=0xc42ab476d0 sp=0xc42ab47640 pc=0x40a90c
> reflect.mapiternext(0xc42d66b740)
> 	/var/lib/jenkins/tools/org.jenkinsci.plugins.golang.GolangInstallation/go1.10.1/src/runtime/hashmap.go:1223 +0x2b fp=0xc42ab476e8 sp=0xc42ab476d0 pc=0x40ba2b
> reflect.Value.MapKeys(0xcf18e0, 0xc4201f1980, 0x15, 0x0, 0x4094f2, 0xc42ab47878)
> 	/var/lib/jenkins/tools/org.jenkinsci.plugins.golang.GolangInstallation/go1.10.1/src/reflect/value.go:1134 +0x13f fp=0xc42ab47790 sp=0xc42ab476e8 pc=0x4c3def
> encoding/json.(*mapEncoder).encode(0xc42a8864f8, 0xc42a7fc4d0, 0xcf18e0, 0xc4201f1980, 0x15, 0xcf0100)
> 	/var/lib/jenkins/tools/org.jenkinsci.plugins.golang.GolangInstallation/go1.10.1/src/encoding/json/encode.go:668 +0xad fp=0xc42ab478f0 sp=0xc42ab47790 pc=0x6b7d7d
> encoding/json.(*mapEncoder).(encoding/json.encode)-fm(0xc42a7fc4d0, 0xcf18e0, 0xc4201f1980, 0x15, 0xc4201f0100)
> 	/var/lib/jenkins/tools/org.jenkinsci.plugins.golang.GolangInstallation/go1.10.1/src/encoding/json/encode.go:700 +0x64 fp=0xc42ab47930 sp=0xc42ab478f0 pc=0x6c2604
> encoding/json.(*encodeState).reflectValue(0xc42a7fc4d0, 0xcf18e0, 0xc4201f1980, 0x15, 0x100)
> 	/var/lib/jenkins/tools/org.jenkinsci.plugins.golang.GolangInstallation/go1.10.1/src/encoding/json/encode.go:325 +0x82 fp=0xc42ab47968 sp=0xc42ab47930 pc=0x6b57a2
> encoding/json.(*encodeState).marshal(0xc42a7fc4d0, 0xcf18e0, 0xc4201f1980, 0x100, 0x0, 0x0)
> 	/var/lib/jenkins/tools/org.jenkinsci.plugins.golang.GolangInstallation/go1.10.1/src/encoding/json/encode.go:298 +0xa5 fp=0xc42ab479a0 sp=0xc42ab47968 pc=0x6b5495
> encoding/json.Marshal(0xcf18e0, 0xc4201f1980, 0xc4200ceb01, 0x510000c42ab47a40, 0x0, 0x51d9c0b44f658c17, 0x412778)
> 	/var/lib/jenkins/tools/org.jenkinsci.plugins.golang.GolangInstallation/go1.10.1/src/encoding/json/encode.go:161 +0x5f fp=0xc42ab479e8 sp=0xc42ab479a0 pc=0x6b4e9f
> bitbucket.mynt.myntra.com/api/knuth/vendor/github.com/myntra/golimit/store.(*Store).SaveRateConfig(0xc4201e2900)
> 	/var/lib/jenkins/workspace/Sfknuth-may31knuth/src/bitbucket.mynt.myntra.com/api/knuth/vendor/github.com/myntra/golimit/store/store.go:471 +0x42 fp=0xc42ab47a50 sp=0xc42ab479e8 pc=0xa85932
> bitbucket.mynt.myntra.com/api/knuth/vendor/github.com/myntra/golimit/store.(*Store).SyncRateConfig(0xc4201e2900, 0x7fc849183ce8, 0xc42cb6b640, 0xc42b3041a0, 0x1c, 0x3c00015f90, 0x9d0101, 0xf89bc0, 0xc42d6a3b60)
> 	/var/lib/jenkins/workspace/Sfknuth-may31knuth/src/bitbucket.mynt.myntra.com/api/knuth/vendor/github.com/myntra/golimit/store/cluster.go:217 +0x1fe fp=0xc42ab47ae8 sp=0xc42ab47a50 pc=0xa8361e
> bitbucket.mynt.myntra.com/api/knuth/vendor/github.com/myntra/golimit


Behaviour and fix can be verified in the following code link:
https://play.golang.org/p/sgHcsTI7WZY